### PR TITLE
Create object to dict and json methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ The `Collection` class provides the following methods, organized by mixin:
 - `take(count)` - Return a new collection with the specified number of items (positive: from beginning, negative: from end)
 - `dump_me()` - Debug method to print collection contents (doesn't stop execution)
 - `dump_me_and_die()` - Debug method to print collection contents and stop execution
+- `to_dict(mode=None)` - Convert items to plain Python structures. With `mode="json"`, ensures JSON-serializable output (datetimes to ISO strings, Decimals to floats, UUIDs to strings, sets to lists, and dict keys to strings)
+- `to_json()` - Return a JSON string using `to_dict(mode="json")`
 
 ### CollectionMap Class
 A specialized map that stores `Collection` instances as values, providing convenient methods for working with grouped data:
@@ -294,6 +296,22 @@ total = sum(item for item in numbers)
 has_even = any(item % 2 == 0 for item in numbers)
 
 # CollectionMap usage
+# Serialization
+from py_collections import Collection
+
+data = Collection([
+    {"name": "Alice", "age": 30},
+    (1, 2, 3),
+    {"tags": {"python", "collections"}},
+])
+
+# Plain Python structures
+structure = data.to_dict()
+
+# JSON-ready structure and JSON string
+json_ready = data.to_dict(mode="json")
+json_text = data.to_json()
+
 from py_collections import CollectionMap
 
 # Create from group_by result

--- a/README.md
+++ b/README.md
@@ -312,6 +312,27 @@ structure = data.to_dict()
 json_ready = data.to_dict(mode="json")
 json_text = data.to_json()
 
+### Pydantic Compatibility
+If your items include Pydantic models, they are supported out of the box:
+
+```python
+from pydantic import BaseModel
+from py_collections import Collection
+
+class User(BaseModel):
+    id: int
+    name: str
+
+users = Collection([User(id=1, name="Alice"), User(id=2, name="Bob")])
+
+# Converts to list of dicts
+users_dict = users.to_dict()
+
+# JSON-ready and stringified
+users_json_ready = users.to_dict(mode="json")
+users_json = users.to_json()
+```
+
 from py_collections import CollectionMap
 
 # Create from group_by result

--- a/examples/to_dict_to_json_example.py
+++ b/examples/to_dict_to_json_example.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating the Collection to_dict and to_json methods.
+"""
+
+import json
+
+from py_collections import Collection
+
+
+def main():
+    data = Collection([
+        {"name": "Alice", "age": 30},
+        (1, 2, 3),
+        {"tags": {"python", "collections"}},
+    ])
+
+    # Convert to plain Python structures
+    structure = data.to_dict()
+    _ = structure
+
+    # JSON-ready structure and string
+    json_ready = data.to_dict(mode="json")
+    json_str = data.to_json()
+
+    # Demonstrate round-trip
+    assert json.loads(json_str) == json_ready
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/mixins/utility/test_to_dict_to_json.py
+++ b/tests/mixins/utility/test_to_dict_to_json.py
@@ -1,0 +1,83 @@
+import json
+
+from src.py_collections.collection import Collection
+
+
+class TestToDictToJson:
+    def test_to_dict_primitives(self):
+        c = Collection([1, 2.5, True, None, "x"])
+        assert c.to_dict() == [1, 2.5, True, None, "x"]
+
+    def test_to_dict_nested_containers(self):
+        c = Collection([
+            {"a": 1, "b": [1, 2, {"c": 3}]},
+            (1, 2),
+            {1: "one"},
+            {"set": {1, 2}},
+        ])
+
+        result_default = c.to_dict()
+        assert isinstance(result_default[0], dict)
+        assert result_default[0]["b"][2]["c"] == 3
+        assert isinstance(result_default[1], list)
+        # default mode keeps non-string keys as-is
+        assert 1 in result_default[2]
+        # sets become lists
+        assert isinstance(result_default[3]["set"], list)
+
+        result_json = c.to_dict(mode="json")
+        # json mode stringifies keys
+        assert "1" in result_json[2]
+        # sets still lists
+        assert isinstance(result_json[3]["set"], list)
+
+    def test_to_dict_dataclass_and_object(self):
+        from dataclasses import dataclass
+
+        @dataclass
+        class D:
+            x: int
+            y: str
+
+        class P:
+            def __init__(self, name, age):
+                self.name = name
+                self.age = age
+
+        c = Collection([D(1, "a"), P("bob", 30)])
+        r = c.to_dict()
+        assert r[0] == {"x": 1, "y": "a"}
+        assert r[1] == {"name": "bob", "age": 30}
+
+    def test_to_dict_collection_inside(self):
+        inner = Collection([1, 2])
+        outer = Collection([inner, 3])
+        assert outer.to_dict() == [[1, 2], 3]
+
+    def test_to_dict_json_special_types(self):
+        import datetime as dt
+        import decimal as dec
+        import uuid
+
+        items = Collection([
+            dt.date(2020, 1, 2),
+            dt.datetime(2020, 1, 2, 3, 4, 5),
+            dt.time(3, 4, 5),
+            dec.Decimal("1.23"),
+            uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        ])
+
+        data = items.to_dict(mode="json")
+        assert data[0] == "2020-01-02"
+        assert data[1].startswith("2020-01-02T03:04:05")
+        assert data[2].startswith("03:04:05")
+        assert data[3] == 1.23
+        assert data[4] == "12345678-1234-5678-1234-567812345678"
+
+    def test_to_json_roundtrip(self):
+        c = Collection([{"a": 1}, {"b": {"c": [1, 2]}}])
+        s = c.to_json()
+        assert isinstance(s, str)
+        loaded = json.loads(s)
+        assert loaded == c.to_dict(mode="json")
+

--- a/tests/mixins/utility/test_to_dict_to_json.py
+++ b/tests/mixins/utility/test_to_dict_to_json.py
@@ -81,3 +81,23 @@ class TestToDictToJson:
         loaded = json.loads(s)
         assert loaded == c.to_dict(mode="json")
 
+    def test_pydantic_models_if_available(self):
+        try:
+            from pydantic import BaseModel  # type: ignore
+        except Exception:
+            return
+
+        class User(BaseModel):
+            id: int
+            name: str
+
+        c = Collection([User(id=1, name="Alice")])
+        d = c.to_dict()
+        assert d == [{"id": 1, "name": "Alice"}]
+
+        dj = c.to_dict(mode="json")
+        assert dj == [{"id": 1, "name": "Alice"}]
+
+        js = c.to_json()
+        assert json.loads(js) == dj
+


### PR DESCRIPTION
Add `to_dict` and `to_json` methods to `Collection` for flexible data serialization to Python dictionaries and JSON strings.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd6dc3e3-5aa9-4887-a4e8-c320afbd0120">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd6dc3e3-5aa9-4887-a4e8-c320afbd0120">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

